### PR TITLE
Improvements to the .gitignore and .hgignore files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,9 @@
+/.hg
 *.py[co]
+*.swp
+*~
+/nbproject
+/.idea
 /build
 /dist
 /django_rules.egg-info

--- a/.hgignore
+++ b/.hgignore
@@ -1,6 +1,11 @@
 # For people using hg-git plugin
 syntax: glob
-*.pyc
-build
-dist
-django_rules.egg-info
+.git/*
+*.py[co]
+*.swp
+*~
+nbproject/*
+.idea/*
+build/*
+dist/*
+django_rules.egg-info/*


### PR DESCRIPTION
Just a couple of additions to the git and mercurial .ignore files to avoid committing work from each other (useful when using plugins such as hg-git), plus ignoring common IDEs such as Netbeans and IDEA's PyCharm.
