### PR TITLE
Missing MANIFEST.in breaks installation

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+include README.textile
+include LICENSE.txt


### PR DESCRIPTION
Since setup.py reads from README.textile, you need to include it in the egg. I added the license file too, for good mesure.

Cheers
