### PR TITLE
Nonexistent perms shouldnt raise

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,7 @@
 /build
 /dist
 /django_rules.egg-info
+bin/
+*distribute*
+lib/
+include/

--- a/django_rules/backends.py
+++ b/django_rules/backends.py
@@ -70,8 +70,7 @@ class ObjectPermissionBackend(object):
         try:
             rule = RulePermission.objects.get(codename = perm, content_type = ctype)
         except RulePermission.DoesNotExist:
-            raise NonexistentPermission('RulePermission with codename %s on model %s does not exist',
-                                        (perm, ctype.model))
+            return False
 
         bound_field = None
         try:

--- a/django_rules/tests/test_core.py
+++ b/django_rules/tests/test_core.py
@@ -63,7 +63,7 @@ class BackendTest(TestCase):
         self.assertFalse(self.not_active_superuser.has_perm('can_ship', self.obj))
 
     def test_nonexistent_perm(self):
-        self.assertRaises(NonexistentPermission, lambda:self.user.has_perm('nonexistent_perm', self.obj))
+        self.assertFalse(self.user.has_perm('nonexistent_perm', self.obj))
 
     def test_nonboolean_attribute(self):
         RulePermission.objects.get_or_create(codename='wrong_rule', field_name='name', content_type=self.ctype, view_param_pk='idDummy',


### PR DESCRIPTION
Hi,

Nonexistent shouldn't raise but return False.

Raising basically requires programmers to surround every has_perm call with a try/except block - that's not acceptable in complex projects.
This fixes the issue (and changes tests accordingly).
